### PR TITLE
Apache access log parser improvements

### DIFF
--- a/scl/apache/apache.conf
+++ b/scl/apache/apache.conf
@@ -20,9 +20,21 @@
 #
 #############################################################################
 
-# combined & common format including vhost
+# Parse apache access.log
+#
+# Formats recognized:
+#
 # LogFormat "%v:%p %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
+#    virtualhost:443 127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.example.com/start.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"
+#
 # LogFormat "%v:%p %h %l %u %t \"%r\" %>s %b" vhost_common
+#    virtualhost:443 127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326
+#
+# LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"" combined
+#    127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.example.com/start.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"
+#
+# LogFormat "%h %l %u %t \"%r\" %>s %b" common
+#    127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326
 block parser apache-accesslog-parser-vhost(prefix() template()) {
     channel {
         rewrite {
@@ -73,6 +85,8 @@ block parser apache-accesslog-parser-combined(prefix() template()) {
 };
 
 block parser apache-accesslog-parser(prefix(".apache.") template("${MESSAGE}")) {
+    # parse into a logstash-like schema
+    # https://github.com/elastic/logstash/blob/v1.4.2/patterns/grok-patterns#L90
     channel {
 
         # parser for formats including vhost:port
@@ -84,7 +98,8 @@ block parser apache-accesslog-parser(prefix(".apache.") template("${MESSAGE}")) 
             parser { apache-accesslog-parser-combined(prefix(`prefix`) template(`template`)); };
         };
 
-        # parser for all formats
+        # mungle values to match Kibana/elastic schema and common to all
+        # supported formats.
         parser {
             csv-parser(
                 prefix(`prefix`)

--- a/scl/apache/apache.conf
+++ b/scl/apache/apache.conf
@@ -25,6 +25,10 @@
 # LogFormat "%v:%p %h %l %u %t \"%r\" %>s %b" vhost_common
 block parser apache-accesslog-parser-vhost(prefix() template()) {
     channel {
+        rewrite {
+            set("`template`" value("1"));
+        };
+        filter { match("^[A-Za-z0-9\-\._]+:[0-9]+ " value("1")); };
         parser {
             csv-parser(
                 dialect(escape-double-char)
@@ -59,7 +63,7 @@ block parser apache-accesslog-parser-combined(prefix() template()) {
                 dialect(escape-double-char)
                 flags(strip-whitespace)
                 delimiters(" ")
-                template($1)
+                template(`template`)
                 quote-pairs('""[]')
                 columns("clientip", "ident", "auth",
                         "timestamp", "rawrequest", "response",
@@ -70,18 +74,14 @@ block parser apache-accesslog-parser-combined(prefix() template()) {
 
 block parser apache-accesslog-parser(prefix(".apache.") template("${MESSAGE}")) {
     channel {
-        rewrite {
-            set("`template`" value("1"));
-        };
 
         # parser for formats including vhost:port
         if {
-            filter { match("^[A-Za-z0-9\-\._]+:[0-9]+ " value("1")); };
-            parser { apache-accesslog-parser-vhost(prefix(`prefix`) template("$1")); };
+            parser { apache-accesslog-parser-vhost(prefix(`prefix`) template(`template`)); };
 
         # parser for standard formats
         } else {
-            parser { apache-accesslog-parser-combined(prefix(`prefix`) template("$1")); };
+            parser { apache-accesslog-parser-combined(prefix(`prefix`) template(`template`)); };
         };
 
         # parser for all formats


### PR DESCRIPTION
Please merge my improvements if you think they are ok, then we can merge the entire branch for 3.21, which is due next week.

I've now documented and tested all supported formats, it nicely works both the common and the combined formats with both with and without the vhost prefix.
